### PR TITLE
Deliver passive checkresults using NRDP outside vpn

### DIFF
--- a/user/hsmonitor/data/config.ini
+++ b/user/hsmonitor/data/config.ini
@@ -1,5 +1,5 @@
 [BufferDB]
-# do not use `localhost`: mySQLdb will (sometimes) fail to connect  
+# do not use `localhost`: mySQLdb will (sometimes) fail to connect
 Host=127.0.0.1
 Username=buffer
 Password=PLACEHOLDER
@@ -26,7 +26,9 @@ MinWait=1
 MaxWait=60
 
 [NagiosPush]
-url=http://194.171.82.1/nrdp
+NRDP_token = nrdp4hisp
+URL=http://194.171.82.1/nrdp
+Backup_URL=http://vpn.hisparc.nl/nrdp
 TriggerRate_Interval=60
 TriggerRate_Warn=0.0:2.0
 TriggerRate_Crit=0.0:10.0

--- a/user/hsmonitor/test/TestForNagiosPushFromHiSparc.py
+++ b/user/hsmonitor/test/TestForNagiosPushFromHiSparc.py
@@ -5,6 +5,8 @@ This process creates other objects and threads.
 
 """
 
+import re
+
 import logging
 import logging.handlers
 import sys
@@ -79,6 +81,12 @@ class HsMonitor(object):
     def createCheckScheduler(self, interpreter):
         # get the nagios configuration section from config file
         nagiosConf = self.cfg.itemsdict('NagiosPush')
+        machine = re.search('([a-z0-9]+).zip',
+                                self.cfg.get('Station', 'Certificate'))
+        if machine is None:
+            nagiosConf['machine_name'] = 'test32bit'
+        else:
+            nagiosConf['machine_name'] = machine.group(1)
         checkSched = CheckScheduler(nagiosConf, interpreter)
         return checkSched
 


### PR DESCRIPTION
Implement BackupURL for NRDP (default: http://vpn.hisparc.nl/nrdp)

When NRDP fails, swap URL and BackupURL. When VPN connection is down, we can still deliver passive checkresults.

![image](https://user-images.githubusercontent.com/6316468/54124899-e50dfa80-4403-11e9-9e64-eb4862f61d01.png)

