### PR TITLE
Update upload url to Utah

### DIFF
--- a/user/diagnostictool/settings.py
+++ b/user/diagnostictool/settings.py
@@ -1,3 +1,3 @@
-DATA_URL = 'http://frome.nikhef.nl/hisparc/upload'
+DATA_URL = 'http://hisparc-raw.chpc.utah.edu/hisparc/upload'
 
 ENABLED_CHECKS = ("data_connection", "vpn_connection", "proxy_settings")

--- a/user/hsmonitor/data/config.ini
+++ b/user/hsmonitor/data/config.ini
@@ -13,7 +13,7 @@ FileLevel=debug
 ScreenLevel=info
 
 [Upload-datastore]
-URL=http://frome.nikhef.nl/hisparc/upload
+URL=http://hisparc-raw.chpc.utah.edu/hisparc/upload
 MinBatchSize=100
 MaxBatchSize=1000
 MinWait=1


### PR DESCRIPTION
However, we can decide to use something like `upload.hisparc.nl` or `raw.hisparc.nl`.